### PR TITLE
Handle the reportUnusedDisableDirectives option.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,8 @@ function translateOptions(cliOptions) {
     cacheFile: cliOptions.cacheFile,
     cacheLocation: cliOptions.cacheLocation,
     fix: cliOptions.fix,
-    allowInlineConfig: cliOptions.inlineConfig
+    allowInlineConfig: cliOptions.inlineConfig,
+    reportUnusedDisableDirectives: cliOptions.reportUnusedDisableDirectives
   };
 }
 


### PR DESCRIPTION
This allows eslint-parallel to forward the `--report-unused-disable-directives` [ command-line flag](https://eslint.org/docs/user-guide/command-line-interface#report-unused-disable-directives) to eslint.